### PR TITLE
Check for a file list of length one

### DIFF
--- a/scripts/build-metadata
+++ b/scripts/build-metadata
@@ -198,6 +198,8 @@ def dump_parameters(params, wmt_config):
 def dump_files(files):
     prefix = os.path.commonprefix(files)
     shortened_files = []
+    if len(files) == 1:
+        prefix = os.path.dirname(prefix) + os.path.sep
     for name in files:
         shortened_files.append(name[len(prefix):])
 
@@ -248,6 +250,8 @@ def build_file_list(config, prefix='.'):
     all_files = []
     for name, component in config['components'].items():
         datadir = os.path.commonprefix(component['files'])
+        if len(component['files']) == 1:
+            datadir = os.path.dirname(datadir) + os.path.sep
         for file in component['files']:
             all_files.append(
                 (file,


### PR DESCRIPTION
The `os.path.commonprefix` function returns the full filepath if there's only one file in its input list. This prevents the file basename from being separated from the file dirname, which resuts in an empty file list in **files.json**.
