### PR TITLE
Add ILAMB metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ This pulls component information from the executor into the server.
 The ownership of all WMT server files is by the group `nobody`,
 so `sudo` privileges on the server machine
 are needed to install the components.
+
+To instead install components manually, use
+
+```
+ssh beach.colorado.edu PATH=/home/csdms/wmt/topoflow.1/conda/bin:\$PATH cmt-config > wmt-config-beach.yaml
+sudo rm -rf ../../db/components
+sudo cp -r metadata/ ../../db/components
+sudo chown -R huttone ../../db/components
+./scripts/build-metadata ./wmt-config-beach.yaml --prefix=../../db/components
+```

--- a/metadata/ILAMB/hooks/pre-stage.py
+++ b/metadata/ILAMB/hooks/pre-stage.py
@@ -1,0 +1,21 @@
+"""A hook for modifying parameter values read from the WMT client."""
+
+import os
+import shutil
+
+from wmt.utils.hook import find_simulation_input_file, yaml_dump
+
+
+file_list = []
+
+
+def execute(env):
+    """Perform pre-stage tasks for running a component.
+
+    Parameters
+    ----------
+    env : dict
+      A dict of component parameter values from WMT.
+
+    """
+    yaml_dump('_env.yaml', env)

--- a/metadata/ILAMB/hooks/pre-stage.py
+++ b/metadata/ILAMB/hooks/pre-stage.py
@@ -3,11 +3,6 @@
 import os
 import shutil
 
-from wmt.utils.hook import find_simulation_input_file, yaml_dump
-
-
-file_list = []
-
 
 def execute(env):
     """Perform pre-stage tasks for running a component.
@@ -18,4 +13,4 @@ def execute(env):
       A dict of component parameter values from WMT.
 
     """
-    yaml_dump('_env.yaml', env)
+    pass

--- a/metadata/ILAMB/wmt.yaml
+++ b/metadata/ILAMB/wmt.yaml
@@ -27,7 +27,7 @@ sections:
       - SiBCASA
       - TEM6
       - TRIPLEX-GHG
-      - VEGAS2.1
+      - VEGAS21
       - VISIT
   - title: CMIP5 models
     members:

--- a/metadata/ILAMB/wmt.yaml
+++ b/metadata/ILAMB/wmt.yaml
@@ -1,3 +1,16 @@
+ignore:
+  - _run_duration
+globals:
+  - _run_duration
+extras:
+  _run_duration:
+    description: Simulation run time
+    value:
+      type: int
+      default: 1
+      range:
+        min: 1
+        max: 1
 sections:
   - title: MsTMIP models
     members:

--- a/metadata/ILAMB/wmt.yaml
+++ b/metadata/ILAMB/wmt.yaml
@@ -1,16 +1,3 @@
-ignore:
-  - _run_duration
-globals:
-  - _run_duration
-extras:
-  _run_duration:
-    description: Simulation run time
-    value:
-      type: int
-      default: 1
-      range:
-        min: 1
-        max: 1
 sections:
   - title: MsTMIP models
     members:

--- a/metadata/ILAMB/wmt.yaml
+++ b/metadata/ILAMB/wmt.yaml
@@ -1,7 +1,8 @@
 ignore:
   - _run_duration
-globals:
-  - _run_duration
+  - _update_time_step
+  - _output_interval
+  - _output_format
 extras:
   _run_duration:
     description: Simulation run time
@@ -11,6 +12,30 @@ extras:
       range:
         min: 1
         max: 1
+  _update_time_step:
+    description: Interval between port updates
+    value:
+      type: int
+      default: 1
+      range:
+        min: 1
+        max: 1
+  _output_interval:
+    description: Number of times to write output
+    value:
+      type: int
+      default: 1
+      range:
+        min: 1
+        max: 1
+  _output_format:
+    description: File format for output
+    value:
+      type: choice
+      default: netcdf
+      choices:
+        - netcdf
+        - vtk
 sections:
   - title: MsTMIP models
     members:

--- a/metadata/ILAMB/wmt.yaml
+++ b/metadata/ILAMB/wmt.yaml
@@ -1,0 +1,64 @@
+ignore:
+  - _run_duration
+globals:
+  - _run_duration
+extras:
+  _run_duration:
+    description: Simulation run time
+    value:
+      type: int
+      default: 1
+      range:
+        min: 1
+        max: 1
+sections:
+  - title: MsTMIP models
+    members:
+      - BIOME-BGC
+      - CLASS-CTEM-N
+      - CLM4
+      - CLM4VIC
+      - DLEM
+      - GTEC
+      - ISAM
+      - LPJ-wsl
+      - ORCHIDEE-LSCE
+      - SiB3
+      - SiBCASA
+      - TEM6
+      - TRIPLEX-GHG
+      - VEGAS2.1
+      - VISIT
+  - title: CMIP5 models
+    members:
+      - bcc-csm1-1-m
+      - BNU-ESM
+      - CanESM2
+      - cesm1_2bgc
+      - CESM1-BGC
+      - GFDL-ESM2G
+      - HadGEM2-ES
+      - inmcm4
+      - IPSL-CM5A-LR
+      - MIROC-ESM
+      - MPI-ESM-LR
+      - MRI-ESM1
+      - NorESM1-ME
+  - title: Study variable
+    members:
+      - study_variable
+  - title: Study duration and scope
+    members:
+      - start_year
+      - end_year
+      - region
+  - title: Statistics and skill scores
+    members:
+      - gp_annualmean
+      - gp_bias
+      - gp_rmse
+      - sm_globalbias
+      - sm_rmse
+      - sm_phase
+      - sm_taylor
+      - sm_interannual

--- a/scripts/build-metadata
+++ b/scripts/build-metadata
@@ -101,13 +101,9 @@ def old_style_parameter(name, param):
     }
 
 
-def make_sections(params, sections):
+def make_sections(ordered_params, params, sections):
     added = set()
-    ordered_params = []
 
-    driver = section_break('Globals')
-    driver['global'] = True
-    ordered_params.append(driver)
     for name in params.keys():
         if params[name].has_key('global') and params[name]['global'] is True:
             try:
@@ -185,14 +181,22 @@ def make_mappers(params, mappers):
 
 def dump_parameters(params, wmt_config):
     add_extras(params, wmt_config['extras'])
-    set_globals(params, wmt_config.get('globals', []))
+
     if wmt_config.has_key('ignore'):
         pop_ignored_params(params, wmt_config['ignore'])
-    sections = make_sections(params, wmt_config.get('sections', []))
-    sections = make_groups(sections, wmt_config.get('groups', {}))
-    sections = make_mappers(sections, wmt_config.get('parameter_mappers', {}))
+
+    plist = []
+    if wmt_config.has_key('globals'):
+        driver = section_break('Globals')
+        driver['global'] = True
+        plist.append(driver)
+        set_globals(params, wmt_config.get('globals', []))
+
+    plist = make_sections(plist, params, wmt_config.get('sections', []))
+    plist = make_groups(plist, wmt_config.get('groups', {}))
+    plist = make_mappers(plist, wmt_config.get('parameter_mappers', {}))
     with open('parameters.json', 'w') as fp:
-        json.dump(sections, fp, indent=4)
+        json.dump(plist, fp, indent=4)
 
 
 def dump_files(files):

--- a/scripts/build-metadata
+++ b/scripts/build-metadata
@@ -292,9 +292,10 @@ def build_metadata(config, prefix='.'):
             with open('wmt.yaml', 'r') as fp:
                 wmt_config = load_wmt_config(fp)
 
-        add_output_vars_to_params(component['parameters'],
-                                  wmt_config['sections'],
-                                  component.get('provides', []))
+        if len(component.get('provides', [])) > 0:
+            add_output_vars_to_params(component['parameters'],
+                                      wmt_config['sections'],
+                                      component.get('provides', []))
 
         with cd(os.path.join(prefix, name, 'db')):
             dump_info(component['info'], component['api'])

--- a/scripts/build-metadata
+++ b/scripts/build-metadata
@@ -180,7 +180,8 @@ def make_mappers(params, mappers):
 
 
 def dump_parameters(params, wmt_config):
-    add_extras(params, wmt_config['extras'])
+    if wmt_config.has_key('extras'):
+        add_extras(params, wmt_config['extras'])
 
     if wmt_config.has_key('ignore'):
         pop_ignored_params(params, wmt_config['ignore'])


### PR DESCRIPTION
I've added the metadata files for ILAMB to display and run in the WMT client. I had to alter the **build-metadata** script to remove some section headings that aren't used by ILAMB.