### PR TITLE
Add wmt_executor_username env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ the paths to where WMT is installed on the server and the executor.
 
     export wmt_project=_testing  # change this
     export wmt_executor="beach.colorado.edu"
+    export wmt_executor_username=$USER  # change this
     export wmt_executor_path=/home/csdms/wmt/$wmt_project
     export wmt_server_path=/data/web/htdocs/wmt/api/$wmt_project
 
@@ -25,9 +26,9 @@ are needed to install the components.
 To instead install components manually, use
 
 ```
-ssh $wmt_executor PATH=$wmt_executor_path/conda/bin:\$PATH cmt-config > wmt-config-beach.yaml
+ssh $wmt_executor_username@$wmt_executor PATH=$wmt_executor_path/conda/bin:\$PATH cmt-config > wmt-config-beach.yaml
 sudo rm -rf $wmt_server_path/db/components
 sudo cp -r metadata/ $wmt_server_path/db/components
 sudo chown -R $USER $wmt_server_path/db/components
-./scripts/build-metadata ./wmt-config-beach.yaml --prefix=../../db/components
+./scripts/build-metadata ./wmt-config-beach.yaml --prefix=$wmt_server_path/db/components
 ```

--- a/scripts/build-metadata
+++ b/scripts/build-metadata
@@ -331,15 +331,16 @@ def fetch_files(config, prefix='.'):
     files_to_fetch = build_file_list(config, prefix=prefix)
 
     hostname = config['host']['hostname']
+    username = os.environ['wmt_executor_username']
 
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     try:
-        ssh.connect(hostname)
+        ssh.connect(hostname, username=username)
     except paramiko.AuthenticationException:
         password = getpass.getpass()
-        ssh.connect(hostname, password=password)
+        ssh.connect(hostname, username=username, password=password)
     except paramiko.SSHException:
         raise
 

--- a/scripts/install-components.sh
+++ b/scripts/install-components.sh
@@ -5,6 +5,10 @@ if [ -z "$wmt_executor" ]; then
     wmt_executor="beach.colorado.edu"
 fi
 
+if [ -z "$wmt_executor_username" ]; then
+    wmt_executor=$USER
+fi
+
 if [ -z "$wmt_executor_path" ]; then
     wmt_executor_path="/home/csdms/wmt/_testing"
 fi
@@ -16,10 +20,11 @@ fi
 project_dir=$(pwd)
 
 echo "WMT executor      = $wmt_executor"
+echo "WMT executor user = $wmt_executor_username"
 echo "WMT executor path = $wmt_executor_path"
 echo "WMT server path   = $wmt_server_path"
 
-ssh $wmt_executor \
+ssh $wmt_executor_username@$wmt_executor \
     PATH=$wmt_executor_path/conda/bin:\$PATH \
     cmt-config > $project_dir/wmt-config-beach.yaml
 


### PR DESCRIPTION
This is needed if the local username isn't the same as the username on the WMT executor.