### PR TITLE
Robustify component installer scripts

### DIFF
--- a/scripts/install-components.sh
+++ b/scripts/install-components.sh
@@ -1,12 +1,16 @@
 #! /usr/bin/env bash
 # Install all components to the db/components directory of a WMT server.
 
+source="${BASH_SOURCE[0]}"
+source_dir="$(cd -P "$(dirname "$source")" && pwd)"
+project_dir=$(dirname $source_dir)
+
 if [ -z "$wmt_executor" ]; then
     wmt_executor="siwenna.colorado.edu"
 fi
 
 if [ -z "$wmt_executor_username" ]; then
-    wmt_executor=$USER
+    wmt_executor_username="wmtuser"
 fi
 
 if [ -z "$wmt_executor_path" ]; then
@@ -17,20 +21,25 @@ if [ -z "$wmt_server_path" ]; then
     wmt_server_path="/data/web/htdocs/wmt/api/_testing"
 fi
 
-project_dir=$(pwd)
-
 echo "WMT executor      = $wmt_executor"
 echo "WMT executor user = $wmt_executor_username"
 echo "WMT executor path = $wmt_executor_path"
 echo "WMT server path   = $wmt_server_path"
+echo "project path      = $project_dir"
 
-ssh $wmt_executor_username@$wmt_executor \
-    PATH=$wmt_executor_path/conda/bin:\$PATH \
-    cmt-config > $project_dir/wmt-config-$wmt_executor.yaml
+if [ ! -f $project_dir/wmt-config-$wmt_executor.yaml ]; then
+    ssh $wmt_executor_username@$wmt_executor \
+	PATH=$wmt_executor_path/conda/bin:\$PATH \
+	cmt-config > $project_dir/wmt-config-$wmt_executor.yaml
+fi
 
-sudo rm -rf $wmt_server_path/db/components
-sudo cp -r $project_dir/metadata/ $wmt_server_path/db/components
-sudo chown -R $USER $wmt_server_path/db/components
+components=$(python $project_dir/scripts/list-components.py)
+
+rm -rf $wmt_server_path/db/components/*
+for c in $components; do
+    echo "- $c"
+    cp -r $project_dir/metadata/$c $wmt_server_path/db/components
+done
 
 $project_dir/scripts/build-metadata \
     $project_dir/wmt-config-$wmt_executor.yaml \

--- a/scripts/list-components.py
+++ b/scripts/list-components.py
@@ -1,0 +1,16 @@
+"""Prints the names of components installed on a WMT executor."""
+import os
+import yaml
+
+wmt_executor = os.environ['wmt_executor']
+cfg_file = 'wmt-config-' + wmt_executor + '.yaml' 
+
+try:
+    with open(cfg_file, 'r') as fp:
+        cfg = yaml.safe_load(fp)
+except IOError:
+    raise
+
+components = cfg['components'].keys()
+for item in components:
+    print item

--- a/scripts/list-components.py
+++ b/scripts/list-components.py
@@ -2,8 +2,10 @@
 import os
 import yaml
 
+project_dir=os.path.dirname(os.path.dirname(__file__))
 wmt_executor = os.environ['wmt_executor']
-cfg_file = 'wmt-config-' + wmt_executor + '.yaml' 
+cfg_file = os.path.join(project_dir,
+                        'wmt-config-{}.yaml'.format(wmt_executor))
 
 try:
     with open(cfg_file, 'r') as fp:


### PR DESCRIPTION
The scripts used to fetch components from an executor and install them on server have long been in need of an update. This PR includes changes that

* allow the scripts to be run from any location on the filesystem, and 
* only install metadata for the components that are on the executor. 