### PR TITLE
Add refresh hook for ILAMB component

### DIFF
--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -98,3 +98,9 @@ def execute(name):
     # Note that I had to give `a+w` permissions to the file.
     with open(parameters_file, 'w') as fp:
         json.dump(params, fp, indent=4)
+
+    # Touch the wsgi script so the client reads the changes.
+    # I had to change the permissions to `a+w` on the wsgi script.
+    # And also add site['bin'].
+    script_path = os.path.join(site['bin'], 'wmt_wsgi_main.py')
+    r = subprocess.call(['touch', script_path])

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -1,0 +1,38 @@
+"""A hook for refreshing a component's metadata."""
+
+from wmt.utils.ssh import get_host_info, open_connection_to_host
+from wmt.utils.hook import yaml_dump
+
+
+hostname = 'siwenna.colorado.edu'
+pbs_dir = '/home/csdms/ilamb/MODELS-by-project/PBS'
+
+
+# Note that I modified info.json to add login credentials.
+def get_pbs_listing():
+    info = get_host_info(hostname)
+    cmd = 'ls {}'.format(pbs_dir)
+    ssh = open_connection_to_host(info['name'],
+                                  info['username'],
+                                  password=info['password'])
+    _, stdout, _ = ssh.exec_command(cmd)
+    file_list = stdout.readlines()
+    ssh.close()
+    for i, item in enumerate(file_list):
+        file_list[i] = item.rstrip()
+    return file_list
+
+
+def execute(name):
+    """Hook called by components/refresh API.
+
+    Parameters
+    ----------
+    name : str
+      The name of the component.
+
+    """
+
+    # Get files listed in MODELS-by-project/PBS directory.
+    pbs_files = get_pbs_listing()
+    yaml_dump('/tmp/files.yaml', pbs_files)

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -1,11 +1,15 @@
 """A hook for refreshing a component's metadata."""
 
+import os
+import yaml
 from wmt.utils.ssh import get_host_info, open_connection_to_host
+from wmt.config import site
 from wmt.utils.hook import yaml_dump
 
 
 hostname = 'siwenna.colorado.edu'
 pbs_dir = '/home/csdms/ilamb/MODELS-by-project/PBS'
+metadata_dir = os.path.join(site['opt'], 'wmt-metadata')
 
 
 # Note that I modified info.json to add login credentials.
@@ -50,3 +54,15 @@ def execute(name):
     # Extract model names from file list, removing duplicates.
     models = get_model_names(pbs_files)
     yaml_dump('/tmp/models.yaml', models)
+
+    # Read the ILAMB wmt.yaml metadata file.
+    metadata_file = os.path.join(metadata_dir, 'metadata', name, 'wmt.yaml')
+    with open(metadata_file, 'r') as fp:
+        metadata = yaml.safe_load(fp)
+
+    # TODO Add new models to the ILAMB metadata.
+
+    # Write the updated ILAMB wmt.yaml metadata file.
+    # Note that I had to give `a+w` permissions to the file.
+    with open(metadata_file, 'w') as fp:
+        yaml.dump(metadata, fp, default_flow_style=False)

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -83,6 +83,7 @@ def execute(name):
 
     # Extract model names from file list, removing duplicates.
     models = get_model_names(pbs_files)
+    models.sort()
 
     # Read the ILAMB parameters.json file.
     parameters_file = os.path.join(site['db'], 'components', name,

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -23,6 +23,16 @@ def get_pbs_listing():
     return file_list
 
 
+def get_model_names(pbs_files):
+    names = []
+    for pbs_file in pbs_files:
+        parts = pbs_file.split('_')
+        name = parts[2]
+        if name not in names:
+            names.append(name)
+    return names
+
+
 def execute(name):
     """Hook called by components/refresh API.
 
@@ -36,3 +46,7 @@ def execute(name):
     # Get files listed in MODELS-by-project/PBS directory.
     pbs_files = get_pbs_listing()
     yaml_dump('/tmp/files.yaml', pbs_files)
+
+    # Extract model names from file list, removing duplicates.
+    models = get_model_names(pbs_files)
+    yaml_dump('/tmp/models.yaml', models)

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -1,7 +1,7 @@
 """A hook for refreshing a component's metadata."""
 
 import os
-import yaml
+import json
 from wmt.utils.ssh import get_host_info, open_connection_to_host
 from wmt.config import site
 from wmt.utils.hook import yaml_dump
@@ -9,7 +9,6 @@ from wmt.utils.hook import yaml_dump
 
 hostname = 'siwenna.colorado.edu'
 pbs_dir = '/home/csdms/ilamb/MODELS-by-project/PBS'
-metadata_dir = os.path.join(site['opt'], 'wmt-metadata')
 
 
 # Note that I modified info.json to add login credentials.
@@ -55,14 +54,15 @@ def execute(name):
     models = get_model_names(pbs_files)
     yaml_dump('/tmp/models.yaml', models)
 
-    # Read the ILAMB wmt.yaml metadata file.
-    metadata_file = os.path.join(metadata_dir, 'metadata', name, 'wmt.yaml')
-    with open(metadata_file, 'r') as fp:
-        metadata = yaml.safe_load(fp)
+    # Read the ILAMB parameters.json file.
+    parameters_file = os.path.join(site['db'], 'components', name,
+                                   'db', 'parameters.json')
+    with open(parameters_file, 'r') as fp:
+        params = json.load(fp)
 
     # TODO Add new models to the ILAMB metadata.
 
-    # Write the updated ILAMB wmt.yaml metadata file.
+    # Write the updated ILAMB parameters.json file.
     # Note that I had to give `a+w` permissions to the file.
-    with open(metadata_file, 'w') as fp:
-        yaml.dump(metadata, fp, default_flow_style=False)
+    with open(parameters_file, 'w') as fp:
+        json.dump(params, fp, indent=4)

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -4,7 +4,6 @@ import os
 import json
 from wmt.utils.ssh import get_host_info, open_connection_to_host
 from wmt.config import site
-from wmt.utils.hook import yaml_dump
 
 
 hostname = 'siwenna.colorado.edu'
@@ -48,11 +47,9 @@ def execute(name):
 
     # Get files listed in MODELS-by-project/PBS directory.
     pbs_files = get_pbs_listing()
-    yaml_dump('/tmp/files.yaml', pbs_files)
 
     # Extract model names from file list, removing duplicates.
     models = get_model_names(pbs_files)
-    yaml_dump('/tmp/models.yaml', models)
 
     # Read the ILAMB parameters.json file.
     parameters_file = os.path.join(site['db'], 'components', name,

--- a/metadata/ILAMB/wmt.yaml
+++ b/metadata/ILAMB/wmt.yaml
@@ -59,7 +59,7 @@ extras:
       type: overview
       default: ''
   _cmip5_models:
-    description: CMIP5 models (click to expand)
+    description: CMIP5 model outputs (click to expand)
     value:
       type: subheading
       default: ''
@@ -168,7 +168,7 @@ extras:
         - 'On'
         - 'Off'
   _mstmip_models:
-    description: MsTMIP models (click to expand)
+    description: MsTMIP model outputs (click to expand)
     value:
       type: subheading
       default: ''
@@ -660,7 +660,7 @@ sections:
       - _model_VISIT
       - _pbs_models
       - _mean_model
-  - title: Model outputs
+  - title: Variables
     members:
       - _overview_variables
       - _variable1

--- a/metadata/ILAMB/wmt.yaml
+++ b/metadata/ILAMB/wmt.yaml
@@ -196,7 +196,6 @@ extras:
       choices:
         - 'On'
         - 'Off'
-
   _model_CLM4VIC:
     description: CLM4VIC
     value:
@@ -293,7 +292,11 @@ extras:
       choices:
         - 'On'
         - 'Off'
-
+  _pbs_models:
+    description: Model outputs uploaded through the PBS (click to expand)
+    value:
+      type: subheading
+      default: ''
   _mean_model:
     description: Include mean model calculation?
     value:
@@ -597,6 +600,8 @@ groups:
     - _model_TRIPLEX-GHG
     - _model_VEGAS21
     - _model_VISIT
+  pbs_models_group:
+    - _pbs_models
   regions_group:
     - _gfed_regions
     - _region_bona
@@ -653,6 +658,7 @@ sections:
       - _model_TRIPLEX-GHG
       - _model_VEGAS21
       - _model_VISIT
+      - _pbs_models
       - _mean_model
   - title: Model outputs
     members:


### PR DESCRIPTION
A component's refresh hook is called by the WMT server's `components/refresh` API (see https://github.com/csdms/wmt/pull/110), which, in turn, can be called by the WMT client's "reload" button (see https://github.com/csdms/wmt-client/pull/117).

Here, I've added a refresh hook for the ILAMB component. It checks an executor (currently hardcoded to siwenna) for files in an upload directory. It then displays info about those files in a menu group in the ILAMB component in the WMT client.