### PR TITLE
Update ILAMB refresh hook for benchmark data

### DIFF
--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -9,13 +9,19 @@ from pbs_server.models import get_model_name, update_parameters
 
 
 hostname = 'siwenna.colorado.edu'
-pbs_dir = '/home/csdms/ilamb/MODELS-by-project/PBS'
+models_dir = '/home/csdms/ilamb/MODELS-by-project/PBS'
+data_dir = '/home/csdms/ilamb/DATA-by-project/PBS'
 
 
 # Note that I modified info.json to add login credentials.
-def get_pbs_listing():
+def get_pbs_listing(pbs_dir):
     """
-    Get a listing of model outputs uploaded through the PBS.
+    Get a listing of model outputs or benchmark data uploaded through the PBS.
+
+    Parameters
+    ----------
+    pbs_dir : str
+      The path to the directory of uploaded PBS files.
 
     Returns
     -------
@@ -46,12 +52,13 @@ def execute(name):
 
     """
 
-    # Get files listed in MODELS-by-project/PBS directory.
-    pbs_files = get_pbs_listing()
+    # Get names of files uploaded through the PBS.
+    models_files = get_pbs_listing(models_dir)
+    data_files = get_pbs_listing(data_dir)
 
     # Extract model names from file list, removing duplicates.
     models = []
-    for pbs_file in pbs_files:
+    for pbs_file in models_files:
         model_name = get_model_name(pbs_file)
         if model_name not in models:
             models.append(model_name)

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -43,27 +43,38 @@ def get_pbs_listing(pbs_dir):
     return file_list
 
 
-def execute(name):
-    """Hook called by components/refresh API.
+def update_models(params):
+    """Updates ILAMB metadata for model outputs uploaded through the PBS.
 
     Parameters
     ----------
-    name : str
-      The name of the component.
+    params : list
+      The WMT parameters for the ILAMB component.
 
     """
-
-    # Get names of files uploaded through the PBS.
     models_files = get_pbs_listing(models_dir)
-    data_files = get_pbs_listing(data_dir)
 
-    # Extract model names from file list, removing duplicates.
+    # Extract model names from file list and sort, removing duplicates.
     model_list = []
     for pbs_file in models_files:
         model_name = models.get_name(pbs_file)
         if model_name not in model_list:
             model_list.append(model_name)
     model_list.sort()
+
+    models.update_parameters(params, model_list)
+
+
+def update_variables(params):
+    """Updates ILAMB metadata for benchmark data uploaded through the PBS.
+
+    Parameters
+    ----------
+    params : list
+      The WMT parameters for the ILAMB component.
+
+    """
+    data_files = get_pbs_listing(data_dir)
 
     # Extract variable names from file list, removing duplicates.
     variable_dict = {}
@@ -72,26 +83,35 @@ def execute(name):
         if variable_name not in variable_dict.keys():
             variable_dict[variable_name] = pbs_file
 
-    # Read the ILAMB parameters.json file.
-    parameters_file = os.path.join(site['db'], 'components', name,
-                                   'db', 'parameters.json')
-    with open(parameters_file, 'r') as fp:
-        params = json.load(fp)
-
-    # Add new models and variables to the ILAMB metadata.
-    models.update_parameters(params, model_list)
     variables.update_parameters(params, variable_dict.keys())
-
-    # Write the updated ILAMB parameters.json file.
-    # Note that I had to give `a+w` permissions to the file.
-    with open(parameters_file, 'w') as fp:
-        json.dump(params, fp, indent=4)
 
     # Create or update the .cfg.tmpl file for each variable.
     for var_name, file_name in variable_dict.items():
         variables.update_template(var_name, file_name)
 
-    # Touch the wsgi script so the client reads the changes.
+
+def execute(name):
+    """Hook called by components/refresh API.
+
+    Parameters
+    ----------
+    name : str
+      The name of the component (here, 'ILAMB').
+
+    """
+    parameters_file = os.path.join(site['db'], 'components', name,
+                                   'db', 'parameters.json')
+    with open(parameters_file, 'r') as fp:
+        params = json.load(fp)
+
+    update_models(params)
+    update_variables(params)
+
+    # Note that I had to give `a+w` permissions to the parameters file.
+    with open(parameters_file, 'w') as fp:
+        json.dump(params, fp, indent=4)
+
+    # Touch the wsgi script so the WMT client reads the changes.
     # I had to change the permissions to `a+w` on the wsgi script.
     # And also add site['bin'].
     script_path = os.path.join(site['bin'], 'wmt_wsgi_main.py')

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -87,6 +87,10 @@ def execute(name):
     with open(parameters_file, 'w') as fp:
         json.dump(params, fp, indent=4)
 
+    # Create or update the .cfg.tmpl file for each variable.
+    for var_name, file_name in variable_dict.items():
+        variables.update_template(var_name, file_name)
+
     # Touch the wsgi script so the client reads the changes.
     # I had to change the permissions to `a+w` on the wsgi script.
     # And also add site['bin'].

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -6,6 +6,7 @@ import json
 from wmt.utils.ssh import get_host_info, open_connection_to_host
 from wmt.config import site
 from pbs_server.models import get_model_name, update_parameters
+from pbs_server.variables import get_variable_name
 
 
 hostname = 'siwenna.colorado.edu'
@@ -63,6 +64,14 @@ def execute(name):
         if model_name not in models:
             models.append(model_name)
     models.sort()
+
+    # Extract variable names from file list, removing duplicates.
+    variables = []
+    for pbs_file in data_files:
+        variable_name = get_variable_name(pbs_file)
+        if variable_name not in variables:
+            variables.append(variable_name)
+    variables.sort()
 
     # Read the ILAMB parameters.json file.
     parameters_file = os.path.join(site['db'], 'components', name,

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -66,12 +66,11 @@ def execute(name):
     model_list.sort()
 
     # Extract variable names from file list, removing duplicates.
-    variable_list = []
+    variable_dict = {}
     for pbs_file in data_files:
         variable_name = variables.get_name(pbs_file)
-        if variable_name not in variable_list:
-            variable_list.append(variable_name)
-    variable_list.sort()
+        if variable_name not in variable_dict.keys():
+            variable_dict[variable_name] = pbs_file
 
     # Read the ILAMB parameters.json file.
     parameters_file = os.path.join(site['db'], 'components', name,
@@ -81,7 +80,7 @@ def execute(name):
 
     # Add new models and variables to the ILAMB metadata.
     models.update_parameters(params, model_list)
-    variables.update_parameters(params, variable_list)
+    variables.update_parameters(params, variable_dict.keys())
 
     # Write the updated ILAMB parameters.json file.
     # Note that I had to give `a+w` permissions to the file.

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -79,8 +79,9 @@ def execute(name):
     with open(parameters_file, 'r') as fp:
         params = json.load(fp)
 
-    # Add new models to the ILAMB metadata.
+    # Add new models and variables to the ILAMB metadata.
     models.update_parameters(params, model_list)
+    variables.update_parameters(params, variable_list)
 
     # Write the updated ILAMB parameters.json file.
     # Note that I had to give `a+w` permissions to the file.

--- a/metadata/ILAMB/hooks/refresh.py
+++ b/metadata/ILAMB/hooks/refresh.py
@@ -5,8 +5,8 @@ import subprocess
 import json
 from wmt.utils.ssh import get_host_info, open_connection_to_host
 from wmt.config import site
-from pbs_server.models import get_model_name, update_parameters
-from pbs_server.variables import get_variable_name
+import pbs_server.models as models
+import pbs_server.variables as variables
 
 
 hostname = 'siwenna.colorado.edu'
@@ -58,20 +58,20 @@ def execute(name):
     data_files = get_pbs_listing(data_dir)
 
     # Extract model names from file list, removing duplicates.
-    models = []
+    model_list = []
     for pbs_file in models_files:
-        model_name = get_model_name(pbs_file)
-        if model_name not in models:
-            models.append(model_name)
-    models.sort()
+        model_name = models.get_name(pbs_file)
+        if model_name not in model_list:
+            model_list.append(model_name)
+    model_list.sort()
 
     # Extract variable names from file list, removing duplicates.
-    variables = []
+    variable_list = []
     for pbs_file in data_files:
-        variable_name = get_variable_name(pbs_file)
-        if variable_name not in variables:
-            variables.append(variable_name)
-    variables.sort()
+        variable_name = variables.get_name(pbs_file)
+        if variable_name not in variable_list:
+            variable_list.append(variable_name)
+    variable_list.sort()
 
     # Read the ILAMB parameters.json file.
     parameters_file = os.path.join(site['db'], 'components', name,
@@ -80,7 +80,7 @@ def execute(name):
         params = json.load(fp)
 
     # Add new models to the ILAMB metadata.
-    update_parameters(params, models)
+    models.update_parameters(params, model_list)
 
     # Write the updated ILAMB parameters.json file.
     # Note that I had to give `a+w` permissions to the file.


### PR DESCRIPTION
The ILAMB `refresh` hook now looks for uploaded benchmark data on the PBS executor and updates the ILAMB configuration if any are found. 